### PR TITLE
Fix height for tall tree views

### DIFF
--- a/styles/opened-files.less
+++ b/styles/opened-files.less
@@ -68,6 +68,12 @@ ul.tab-bar>li.tab.of-highlight:after {
         z-index: 10;
         margin-left: .5em;
       }
+      &.list-nested-item {
+        .list-tree.entries {
+          max-height: 25vh;
+          overflow: auto;
+        }
+      }
     }
     .file {
       .icon-paintcan {


### PR DESCRIPTION
This limits the height of the toggled tree view to take up 25% of screen space so it never overlaps the tree view completely.

Fixes #16 
